### PR TITLE
allow overriding restful setting on per-route basis

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ Additionally, some configuration can be passed on a per-route basis
 
 * 'key' - the key used in the view contexts and payloads for the crumb (defaults to whatever the key value in the main settings is)
 * 'source' - can be either 'payload' or 'query' specifying how the crumb will be sent in requests (defaults to payload)
+* 'restful' - an override for the server's 'restful' setting (defaults to match server setting)

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,15 +22,17 @@ internals.defaults = {
 // Not used in restful mode
 internals.routeDefaults = {
     key: 'crumb',                   // query or payload key
-    source: 'payload'               // Crumb key source: 'payload', 'query'
+    source: 'payload',              // Crumb key source: 'payload', 'query'
+    restful: false
 };
 
 
 exports.register = function (plugin, options, next) {
 
     var settings = plugin.hapi.utils.applyToDefaults(internals.defaults, options || {});
-    // copy the key from internals.defaults to internals.routeDefaults for consistency
+    // copy the key and restful settings from internals.defaults to internals.routeDefaults for consistency
     internals.routeDefaults.key = settings.key;
+    internals.routeDefaults.restful = settings.restful;
 
     plugin.state(settings.key, settings.cookieOptions);
 
@@ -59,7 +61,8 @@ exports.register = function (plugin, options, next) {
 
         // Validate crumb
 
-        if (settings.restful === false) {
+        if (settings.restful === false &&
+            (!request.route.plugins._crumb || request.route.plugins._crumb.restful === false)) {
 
             if (request.method !== 'post' ||
                 !request.route.plugins._crumb) {

--- a/test/restful.js
+++ b/test/restful.js
@@ -87,6 +87,13 @@ describe('Crumb', function () {
                     return reply('valid');
                 }
             },
+            {
+                method: 'POST', path: '/8', config: { plugins: { crumb: { restful: false } } }, handler: function (request, reply) {
+
+                    expect(request.payload).to.deep.equal({ key: 'value' });
+                    return reply('valid');
+                }
+            }
 
         ]);
 
@@ -150,7 +157,12 @@ describe('Crumb', function () {
                                                     server.inject({ method: 'POST', url: '/7', payload: '{ "key": "value" }' }, function (res) {
 
                                                         expect(res.result).to.equal('valid');
-                                                        done();
+
+                                                        server.inject({ method: 'POST', url: '/8', payload: '{ "key": "value" }', headers: validHeader }, function (res) {
+
+                                                            expect(res.result).to.equal('valid');
+                                                            done();
+                                                        });
                                                     });
                                                 });
                                             });


### PR DESCRIPTION
This way you can default your app to using `restful` but allow individual routes to override the option and accept the csrf token as part of the payload.
