### PR TITLE
Changed server.state URL to Hapijs API docs: http://hapijs.com/api#serve...

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following options are available when registering the plugin
 * 'size' - the length of the crumb to generate (defaults to 43, which is 256 bits, see [cryptile](https://github.com/hueniverse/cryptiles) for more information)
 * 'autoGenerate' - whether to automatically generate a new crumb for requests (defaults to true)
 * 'addToViewContext' - whether to automatically add the crumb to view contexts as the given key (defaults to true)
-* 'cookieOptions' - storage options for the cookie containing the crumb, see the [server.state](https://github.com/hapijs/hapi/blob/master/docs/Reference.md#serverstatename-options) documentation of hapi for more information
+* 'cookieOptions' - storage options for the cookie containing the crumb, see the [server.state](http://hapijs.com/api#serverstatename-options) documentation of hapi for more information
 * 'restful' - RESTful mode that validates crumb tokens from "X-CSRF-Token" request header for POST, PUT, PATCH and DELETE server routes. Disables payload/query crumb validation (defaults to false)
 * 'skip' - a function with the signature of function (request reply) {}, which when provided, is called for every request. If the provided function returns true, validation and generation of crumb is skipped (defaults to false)
 * 'allowOrigins' - an array of origins to set crumb cookie on if CORS is enabled. Supports '\*' wildcards for domain segments and port ie '\*.domain.com' or 'domain.com:\*'. '\*' by itself is not allowed. Defaults to the server's `cors.origin` setting by default


### PR DESCRIPTION
Updated URL for Hapi docs