### PR TITLE
fix internals.originParser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -229,7 +229,7 @@ internals.originParser = function (origin, allowOrigins, request) {
         }
         else {
             for (var j = 0, jl = this._originAllowParts.length; j < jl; ++j) {
-                this._match = this._originAllowParts[j] === '*' || this._originAllowParts[j] === this._originParts[j];
+                this._match = this._originAllowParts[j] === '//*' || this._originAllowParts[j] === this._originParts[j];
                 if (!this._match) {
                     break;
                 }

--- a/test/index.js
+++ b/test/index.js
@@ -160,7 +160,7 @@ describe('Crumb', function () {
                                             expect(cookie).to.contain('crumb');
 
                                             var headers = {};
-                                            headers.origin = '127.0.0.1';
+                                            headers.origin = 'http://127.0.0.1';
 
                                             server.inject({method: 'GET', url: '/1', headers: headers}, function(res) {
 
@@ -404,7 +404,7 @@ describe('Crumb', function () {
 
                 server.inject({ method: 'GET', url: '/1', headers: headers }, function (res) {
 
-                    headers.origin = '127.0.0.1';
+                    headers.origin = 'http://127.0.0.1';
 
                     var header = res.headers['set-cookie'];
                     expect(header).to.not.exist();
@@ -469,23 +469,23 @@ describe('Crumb', function () {
                 }
             }
         ]);
-        server.register({ register: Crumb, options: { allowOrigins: ['127.0.0.1']} }, function (err) {
+        server.register({ register: Crumb, options: { allowOrigins: ['http://127.0.0.1']} }, function (err) {
             expect(err).to.not.exist();
             var headers = {};
-            headers.origin = '127.0.0.1';
+            headers.origin = 'http://127.0.0.1';
             server.inject({ method: 'GET', url: '/1', headers: headers }, function (res) {
 
                 var header = res.headers['set-cookie'];
                 expect(header[0]).to.contain('crumb');
 
-                headers.origin = '127.0.0.2';
+                headers.origin = 'http://127.0.0.2';
 
                 server.inject({ method: 'GET', url: '/1', headers: headers }, function (res) {
 
                     var header = res.headers['set-cookie'];
                     expect(header).to.not.exist();
 
-                    headers.origin = '127.0.0.1:2000';
+                    headers.origin = 'http://127.0.0.1:2000';
 
                     server.inject({ method: 'GET', url: '/1', headers: headers }, function (res) {
 
@@ -510,7 +510,7 @@ describe('Crumb', function () {
     it('does set crumb cookie if allowOrigins not set and CORS enabled with server.settings.cors.origin set', function (done) {
 
         var server = new Hapi.Server();
-        server.connection({ host: 'localhost', port: 80, routes: { cors: { origin: ['127.0.0.1'] } } });
+        server.connection({ host: 'localhost', port: 80, routes: { cors: { origin: ['http://127.0.0.1'] } } });
         server.route([
             {
                 method: 'GET', path: '/1', handler: function (request, reply) {
@@ -522,20 +522,20 @@ describe('Crumb', function () {
         server.register({ register: Crumb, options: null }, function (err) {
             expect(err).to.not.exist();
             var headers = {};
-            headers.origin = '127.0.0.1';
+            headers.origin = 'http://127.0.0.1';
             server.inject({ method: 'GET', url: '/1', headers: headers }, function (res) {
 
                 var header = res.headers['set-cookie'];
                 expect(header[0]).to.contain('crumb');
 
-                headers.origin = '127.0.0.2';
+                headers.origin = 'http://127.0.0.2';
 
                 server.inject({ method: 'GET', url: '/1', headers: headers }, function (res) {
 
                     var header = res.headers['set-cookie'];
                     expect(header).to.not.exist();
 
-                    headers.origin = '127.0.0.1:2000';
+                    headers.origin = 'http://127.0.0.1:2000';
 
                     server.inject({ method: 'GET', url: '/1', headers: headers }, function (res) {
 
@@ -573,7 +573,7 @@ describe('Crumb', function () {
         server.register({ register: Crumb, options: null }, function (err) {
             expect(err).to.not.exist();
             var headers = {};
-            headers.origin = '127.0.0.1';
+            headers.origin = 'http://127.0.0.1';
             server.inject({ method: 'GET', url: '/1', headers: headers }, function (res) {
 
                 var header = res.headers['set-cookie'];
@@ -596,22 +596,22 @@ describe('Crumb', function () {
                 }
             }
         ]);
-        server.register({ register: Crumb, options: { allowOrigins: ['127.0.0.1:2000']} }, function (err) {
+        server.register({ register: Crumb, options: { allowOrigins: ['http://127.0.0.1:2000']} }, function (err) {
             expect(err).to.not.exist();
             var headers = {};
-            headers.origin = '127.0.0.1:2000';
+            headers.origin = 'http://127.0.0.1:2000';
             server.inject({ method: 'GET', url: '/1', headers: headers }, function (res) {
 
                 var header = res.headers['set-cookie'];
                 expect(header[0]).to.contain('crumb');
 
-                headers.origin = '127.0.0.1:1000';
+                headers.origin = 'http://127.0.0.1:1000';
                 server.inject({ method: 'GET', url: '/1', headers: headers }, function (res) {
 
                     var header = res.headers['set-cookie'];
                     expect(header).to.not.exist();
 
-                    headers.origin = '127.0.0.1';
+                    headers.origin = 'http://127.0.0.1';
                     server.inject({ method: 'GET', url: '/1', headers: headers }, function (res) {
 
                         var header = res.headers['set-cookie'];
@@ -636,22 +636,22 @@ describe('Crumb', function () {
                 }
             }
         ]);
-        server.register({ register: Crumb, options: { allowOrigins: ['127.0.0.1:*', '*.test.com']} }, function (err) {
+        server.register({ register: Crumb, options: { allowOrigins: ['http://127.0.0.1:*', 'http://*.test.com']} }, function (err) {
             expect(err).to.not.exist();
             var headers = {};
-            headers.origin = '127.0.0.1:2000';
+            headers.origin = 'http://127.0.0.1:2000';
             server.inject({ method: 'GET', url: '/1', headers: headers }, function (res) {
 
                 var header = res.headers['set-cookie'];
                 expect(header[0]).to.contain('crumb');
 
-                headers.origin = 'foo.test.com';
+                headers.origin = 'http://*.test.com';
                 server.inject({ method: 'GET', url: '/1', headers: headers }, function (res) {
 
-                    //expect(header[0]).to.contain('crumb');
+                    var header = res.headers['set-cookie'];
                     expect(header[0]).to.contain('crumb');
 
-                    headers.origin = 'foo.tesc.com';
+                    headers.origin = 'http://foo.tesc.com';
 
                     server.inject({ method: 'GET', url: '/1', headers: headers }, function (res) {
 


### PR DESCRIPTION
### Test case before fix
```javascript
HOST => 0.0.0.0:9000
REQUEST_HOST => 127.0.0.1:9000
HOST === REQUEST_HOST => false

ORIGIN => "http://wega.demo:8080"
ALLOWS_ORIGINS => ["http://127.0.0.1:8080"]

this._origin  = origin.split(':') => ["http","//wega.demo","8080"]
this._originPort = this._origin.length === 2 ? this._origin[1] : null => null
this._originParts = this._origin[0].split('.') => ["http"]

allowOrigins[i] => http://127.0.0.1:8080

this._originAllow = allowOrigins[i].split(':') => ["http","//127.0.0.1","8080"]
this._originAllowPort = this._originAllow.length === 2 ? this._originAllow[1] : null => null
this._originAllowParts = this._originAllow[0].split('.') => ["http"]

this._originAllowParts[j] => http
this._originParts[j] => http

this._originAllowParts[j] === '*' => false
this._originAllowParts[j] === this._originParts[j] => true

MATCH => true

RETURN MATCH => true
```

We can see that we have differences between `origin` and `allowOrigins` but method returns `true` - `failed`

### Test case after fix
```javascript
HOST => 0.0.0.0:9000
REQUEST_HOST => 127.0.0.1:9000
HOST === REQUEST_HOST => false

ORIGIN => "http://wega.demo:8080"
ALLOWS_ORIGINS => ["http://127.0.0.1:8080"]

this._origin  = origin.split(':') => ["http","//wega.demo","8080"]
this._originPort = this._origin.length === 3 ? this._origin[2] : null => "8080"
this._originParts = this._origin[1].split('.') => ["//wega","demo"]

allowOrigins[i] => http://127.0.0.1:8080

this._originAllow = allowOrigins[i].split(':') => ["http","//127.0.0.1","8080"]
this._originAllowPort = this._originAllow.length === 3 ? this._originAllow[2] : null => "8080"
this._originAllowParts = this._originAllow[1].split('.') => ["//127","0","0","1"]

this._originAllowParts[j] => //127
this._originParts[j] => //wega

this._originAllowParts[j] === '*' => false
this._originAllowParts[j] === this._originParts[j] => false

MATCH => false

END METHOD - RETURN MATCH => false
```

With the `fix`, result is correct because method returns `false` - `correct`

Thanks to add this fix in your plugin ASAP because I think is a very important issue.

Best regards.