### PR TITLE
Clarify skip function signature in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The following options are available when registering the plugin
 * 'addToViewContext' - whether to automatically add the crumb to view contexts as the given key (defaults to true)
 * 'cookieOptions' - storage options for the cookie containing the crumb, see the [server.state](http://hapijs.com/api#serverstatename-options) documentation of hapi for more information
 * 'restful' - RESTful mode that validates crumb tokens from "X-CSRF-Token" request header for POST, PUT, PATCH and DELETE server routes. Disables payload/query crumb validation (defaults to false)
-* 'skip' - a function with the signature of function (request reply) {}, which when provided, is called for every request. If the provided function returns true, validation and generation of crumb is skipped (defaults to false)
+* 'skip' - a function with the signature of `function (request, reply) {}`, which when provided, is called for every request. If the provided function returns true, validation and generation of crumb is skipped (defaults to false)
 * 'allowOrigins' - an array of origins to set crumb cookie on if CORS is enabled. Supports '\*' wildcards for domain segments and port ie '\*.domain.com' or 'domain.com:\*'. '\*' by itself is not allowed. Defaults to the server's `cors.origin` setting by default
 
 Additionally, some configuration can be passed on a per-route basis


### PR DESCRIPTION
Howdy. Thanks for this module!

I guess this PR is kind of a matter of taste, but as I read the documentation I felt that the way the function signature was described was kind of odd. So here is a PR that makes it look more like I would expect it to. It has these pros (as I see it)

- It is now possible to actually copy paste the signature into your own code (and everyone likes to copy paste things from the internet into their codebases and terminals)
- It is easier to see that this part is actually code and not "text".

Anyway, as I said, I guess it also is somewhat a matter of taste. So if it does not fit with your taste, no offence taken :)

Thanks again for an awesome module (not to mention hapi itself). Have a great weekend!