### PR TITLE
Return error during plugin registration for invalid options.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,11 @@ internals.defaults = {
 
 exports.register = function (server, options, next) {
 
-    Joi.assert(options, internals.schema, 'Invalid crumb options');
+    var validateOptions = internals.schema.validate(options);
+    if (validateOptions.error) {
+        return next(validateOptions.error);
+    }
+
     var settings = Hoek.applyToDefaults(internals.defaults, options);
 
     var routeDefaults = {

--- a/test/index.js
+++ b/test/index.js
@@ -258,6 +258,25 @@ describe('Crumb', function () {
         });
     });
 
+    it('should fail to register with bad options', function (done) {
+
+        var server = new Hapi.Server();
+        server.connection();
+
+        server.register({
+            register: Crumb,
+            options: {
+                foo: 'bar'
+            }
+        }, function(err) {
+
+            expect(err).to.exist();
+            expect(err.name).to.equal('ValidationError');
+            expect(err.message).to.equal('foo is not allowed');
+            done();
+        });
+    });
+
     it('route uses crumb when route.config.plugins.crumb set to true and autoGenerate set to false', function (done) {
 
         var server = new Hapi.Server();
@@ -375,11 +394,12 @@ describe('Crumb', function () {
         var server = new Hapi.Server();
         server.connection();
 
-        expect(function () {
-
-            server.register({ register: Crumb, options: { allowOrigins: ['*'] } }, function (err) {});
-        }).to.throw(/Invalid crumb options/);
-        done();
+        server.register({ register: Crumb, options: { allowOrigins: ['*'] } }, function (err) {
+            expect(err).to.exist();
+            expect(err.name).to.equal('ValidationError');
+            expect(err.message).to.equal('allowOrigins position 0 contains an excluded value');
+            done();
+        });
     });
 
     it('does not set crumb cookie insecurely', function (done) {


### PR DESCRIPTION
Crumb was throwing an exception for invalid options rather than returning an error to the registration function callback (http://hapijs.com/api#serverregisterplugins-options-callback). 

This PR changes the behaviour to return an error to the registration function callback. I'm not sure what the preferred behaviour is - I noticed that the lout plugin returns an error (rather than throwing - https://github.com/hapijs/lout/blob/master/lib/index.js#L43) - this change mimics that behaviour.