### PR TITLE
Fixes #74 -- restful configured through routes is not superceded by global config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -87,8 +87,8 @@ exports.register = function (server, options, next) {
 
         // Validate crumb
 
-        if (settings.restful === false ||
-            (!request.route.settings.plugins._crumb || request.route.settings.plugins._crumb.restful === false)) {
+        const routeIsRestful = (request.route.settings.plugins._crumb && request.route.settings.plugins._crumb.restful === true);
+        if (!routeIsRestful && settings.restful === false ) {
 
             if (request.method !== 'post' ||
                 !request.route.settings.plugins._crumb) {

--- a/test/index.js
+++ b/test/index.js
@@ -656,7 +656,7 @@ describe('Crumb', () => {
                                                         delete validHeader['x-csrf-token'];
                                                         server.inject({ method: 'POST', url: '/8', payload: JSON.stringify(payload), headers: validHeader }, (res12) => {
 
-                                                            expect(res12.result).to.equal('valid');
+                                                            expect(res12.statusCode).to.equal(403);
                                                             done();
                                                         });
                                                     });


### PR DESCRIPTION
Also fixes a test case which should have been failing. For that test case, restful is set as true through the plugin config, but passes without the CSRF header, instead relying on the payload. If this is too stringent let me know.