### PR TITLE
Documentation Improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,34 +6,73 @@ CSRF crumb generation and validation for [**hapi**](https://github.com/hapijs/ha
 
 Lead Maintainer: [Marcus Stong](https://github.com/stongo)
 
-## What to Use Crumb for and When to Use It
+## About CSRF
+### What to Use Crumb for and When to Use It
 
 Crumb is used to diminish CSRF attacks using a random unique token that is validated on the server side.
 
-Crumb may be used whenever you want to prevent malicious code to execute system commands, that are performed by HTTP requests. For example, if users are able to publish code on your website, malicious code added by a user could force every other user who opens the page, to load and execute code from a third party website e.g. via an HTML image tag. With Crumb implemented into your hapi.js application, you are able to verify requests with unique tokens and prevent the execution of malicious requests. 
+Crumb may be used whenever you want to prevent malicious code to execute system commands, that are performed by HTTP requests. For example, if users are able to publish code on your website, malicious code added by a user could force every other user who opens the page, to load and execute code from a third party website e.g. via an HTML image tag. With Crumb implemented into your hapi.js application, you are able to verify requests with unique tokens and prevent the execution of malicious requests.
 
-## CORS
+### CORS
 
 Crumb has been refactored to securely work with CORS, as [OWASP](https://www.owasp.org/index.php/HTML5_Security_Cheat_Sheet#Cross_Origin_Resource_Sharing) recommends using CSRF protection with CORS.
 
 **It is highly discouraged to have a production servers `cors.origin` setting set to "[\*]" or "true" with Crumb as it will leak the crumb token to potentially malicious sites**
 
 
+## Usage
 
-## Plugin Options
+```js
+  const Hapi = require('hapi');
+  const Crumb = require('crumb');
 
-The following options are available when registering the plugin
+  const server = new Hapi.Server();
 
-* 'key' - the name of the cookie to store the csrf crumb in (defaults to 'crumb')
-* 'size' - the length of the crumb to generate (defaults to 43, which is 256 bits, see [cryptile](https://github.com/hueniverse/cryptiles) for more information)
-* 'autoGenerate' - whether to automatically generate a new crumb for requests (defaults to true)
-* 'addToViewContext' - whether to automatically add the crumb to view contexts as the given key (defaults to true)
-* 'cookieOptions' - storage options for the cookie containing the crumb, see the [server.state](http://hapijs.com/api#serverstatename-options) documentation of hapi for more information
-* 'restful' - RESTful mode that validates crumb tokens from "X-CSRF-Token" request header for POST, PUT, PATCH and DELETE server routes. Disables payload/query crumb validation (defaults to false)
-* 'skip' - a function with the signature of `function (request, reply) {}`, which when provided, is called for every request. If the provided function returns true, validation and generation of crumb is skipped (defaults to false)
+  server.connection({ port: 8000 });
 
-Additionally, some configuration can be passed on a per-route basis
+  server.register({
+    register: crumb,
 
-* 'key' - the key used in the view contexts and payloads for the crumb (defaults to whatever the key value in the main settings is)
-* 'source' - can be either 'payload' or 'query' specifying how the crumb will be sent in requests (defaults to payload)
-* 'restful' - an override for the server's 'restful' setting (defaults to match server setting)
+    // plugin options
+    options: {}
+  });
+
+  server.route({
+    path: '/login',
+    method: 'GET',
+    config: {
+      plugins: {
+        // route specific options
+        crumb: {}
+      },
+      handler(request, reply) {
+        // this requires to have a view engine configured
+        return reply.view('some-view');
+      }
+    }
+  });
+```
+
+For a complete example see [the examples folder](./example).
+
+## Options
+
+The following options are available when registering the plugin.
+
+### Registration options
+
+  * `key` - the name of the cookie to store the csrf crumb into. Defaults to `crumb`.
+  * `size` - the length of the crumb to generate. Defaults to `43`, which is 256 bits, see [cryptile](https://github.com/hapijs/cryptiles) for more information.
+  * `autoGenerate` - whether to automatically generate a new crumb for requests. Defaults to `true`.
+  * `addToViewContext` - whether to automatically add the crumb to view contexts as the given key. Defaults to `true`.
+  * `cookieOptions` - storage options for the cookie containing the crumb, see the [server.state](http://hapijs.com/api#serverstatename-options) documentation of hapi for more information. Default to `cookieOptions.path=/`
+  * `restful` - RESTful mode that validates crumb tokens from *"X-CSRF-Token"* request header for **POST**, **PUT**, **PATCH** and **DELETE** server routes. Disables payload/query crumb validation. Defaults to `false`.
+  * `skip` - a function with the signature of `function (request, reply) {}`, which when provided, is called for every request. If the provided function returns true, validation and generation of crumb is skipped. Defaults to `false`.
+
+### Routes configuration
+
+Additionally, some configuration can be passed on a per-route basis.
+
+  * `key` - the key used in the view contexts and payloads for the crumb. Defaults to `plugin.key`.
+  * `source` - can be either `payload` or `query` specifying how the crumb will be sent in requests. Defaults to `payload`.
+  * `restful` - an override for the server's 'restful' setting. Defaults to `plugin.restful`.

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
     "hapi": ">=12.x.x"
   },
   "devDependencies": {
-    "code": "2.x.x",
+    "code": "^4.0.0",
     "handlebars": "^4.0.5",
-    "hapi": "13.x.x",
-    "lab": "10.x.x",
+    "hapi": "^13.5.3",
+    "lab": "^10.9.0",
     "vision": "^4.0.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "hapi": ">=12.x.x"
   },
   "devDependencies": {
-    "code": "^4.0.0",
-    "handlebars": "^4.0.5",
-    "hapi": "^13.5.3",
-    "lab": "^10.9.0",
-    "vision": "^4.0.0"
+    "code": "4.x.x",
+    "handlebars": "4.x.x",
+    "hapi": "13.x.x",
+    "lab": "10.x.x",
+    "vision": "4.x.x"
   },
   "scripts": {
     "test": "lab -r console -t 100 -a code -L",

--- a/test/index.js
+++ b/test/index.js
@@ -54,7 +54,7 @@ describe('Crumb', () => {
             {
                 method: 'POST', path: '/2', handler: (request, reply) => {
 
-                    expect(request.payload).to.deep.equal({ key: 'value' });
+                    expect(request.payload).to.equal({ key: 'value' });
                     return reply('valid');
                 }
             },
@@ -546,7 +546,7 @@ describe('Crumb', () => {
             {
                 method: 'POST', path: '/2', handler: (request, reply) => {
 
-                    expect(request.payload).to.deep.equal({ key: 'value' });
+                    expect(request.payload).to.equal({ key: 'value' });
                     return reply('valid');
                 }
             },
@@ -559,14 +559,14 @@ describe('Crumb', () => {
             {
                 method: 'PUT', path: '/4', handler: (request, reply) => {
 
-                    expect(request.payload).to.deep.equal({ key: 'value' });
+                    expect(request.payload).to.equal({ key: 'value' });
                     return reply('valid');
                 }
             },
             {
                 method: 'PATCH', path: '/5', handler: (request, reply) => {
 
-                    expect(request.payload).to.deep.equal({ key: 'value' });
+                    expect(request.payload).to.equal({ key: 'value' });
                     return reply('valid');
                 }
             },
@@ -579,14 +579,14 @@ describe('Crumb', () => {
             {
                 method: 'POST', path: '/7', config: { plugins: { crumb: false } }, handler: (request, reply) => {
 
-                    expect(request.payload).to.deep.equal({ key: 'value' });
+                    expect(request.payload).to.equal({ key: 'value' });
                     return reply('valid');
                 }
             },
             {
                 method: 'POST', path: '/8', config: { plugins: { crumb: { restful: false, source: 'payload' } } }, handler: (request, reply) => {
 
-                    expect(request.payload).to.deep.equal({ key: 'value' });
+                    expect(request.payload).to.equal({ key: 'value' });
                     return reply('valid');
                 }
             }


### PR DESCRIPTION
Hey! I just updated this project documentation to make it easier to read, and similar to other hapi modules docs.

I tried to update the `devDependencies`, however I got the following problems with some `devDeps`:
- Could not upgrade to `lab@11`, because a breaking additional rule on that version (forces shorthand properties). I can update to use them if you are ok with that.
- Could not upgrade to `hapi@15` becase I am getting a weird error regarding TypedArrays and `Buffer.from`. I´ll dig later on that problem (perhaps is due I am using node@5).

Let me know what you think about this.