### PR TITLE
Auto generate fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,8 +66,7 @@ exports.register = function (server, options, next) {
         // Validate incoming crumb
 
         if (typeof request.route.settings.plugins._crumb === 'undefined') {
-            if (request.route.settings.plugins.crumb ||
-                !request.route.settings.plugins.hasOwnProperty('crumb')) {
+            if (request.route.settings.plugins.crumb) {
 
                 request.route.settings.plugins._crumb = Hoek.applyToDefaults(routeDefaults, request.route.settings.plugins.crumb || {});
             }
@@ -78,8 +77,7 @@ exports.register = function (server, options, next) {
 
         // Set crumb cookie and calculate crumb
 
-        if ((settings.autoGenerate ||
-            request.route.settings.plugins._crumb) &&
+        if (settings.autoGenerate &&
             (request.route.settings.cors ? checkCORS(request) : true)) {
 
             generate(request, reply);

--- a/lib/index.js
+++ b/lib/index.js
@@ -67,7 +67,7 @@ exports.register = function (server, options, next) {
 
         if (typeof request.route.settings.plugins._crumb === 'undefined') {
             if (request.route.settings.plugins.crumb ||
-                !request.route.settings.plugins.hasOwnProperty('crumb') && settings.autoGenerate) {
+                !request.route.settings.plugins.hasOwnProperty('crumb')) {
 
                 request.route.settings.plugins._crumb = Hoek.applyToDefaults(routeDefaults, request.route.settings.plugins.crumb || {});
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,21 +66,13 @@ exports.register = function (server, options, next) {
         // Validate incoming crumb
 
         if (typeof request.route.settings.plugins._crumb === 'undefined') {
-            if (request.route.settings.plugins.crumb) {
-
-                request.route.settings.plugins._crumb = Hoek.applyToDefaults(routeDefaults, request.route.settings.plugins.crumb || {});
-            }
-            else {
-                request.route.settings.plugins._crumb = false;
-            }
+            request.route.settings.plugins._crumb = Hoek.applyToDefaults(routeDefaults, request.route.settings.plugins.crumb || {});
         }
 
         // Set crumb cookie and calculate crumb
 
-        if (settings.autoGenerate &&
-            (request.route.settings.cors ? checkCORS(request) : true)) {
-
-            generate(request, reply);
+        if ((request.route.settings.cors ? checkCORS(request) : true)) {
+            generate(request, reply, settings.autoGenerate);
         }
 
         // Validate crumb
@@ -160,10 +152,10 @@ exports.register = function (server, options, next) {
         return true;
     };
 
-    const generate = function (request, reply) {
+    const generate = function (request, reply, autoGenerate) {
 
         let crumb = request.state[settings.key];
-        if (!crumb) {
+        if (!crumb && autoGenerate) {
             crumb = Cryptiles.randomString(settings.size);
             reply.state(settings.key, crumb, settings.cookieOptions);
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,22 +66,13 @@ exports.register = function (server, options, next) {
         // Validate incoming crumb
 
         if (typeof request.route.settings.plugins._crumb === 'undefined') {
-            if (request.route.settings.plugins.crumb ||
-                !request.route.settings.plugins.hasOwnProperty('crumb')) {
-
-                request.route.settings.plugins._crumb = Hoek.applyToDefaults(routeDefaults, request.route.settings.plugins.crumb || {});
-            }
-            else {
-                request.route.settings.plugins._crumb = false;
-            }
+            request.route.settings.plugins._crumb = Hoek.applyToDefaults(routeDefaults, request.route.settings.plugins.crumb || {});
         }
 
         // Set crumb cookie and calculate crumb
 
-        if ((settings.autoGenerate ||
-            request.route.settings.plugins._crumb) &&
+        if (settings.autoGenerate &&
             (request.route.settings.cors ? checkCORS(request) : true)) {
-
             generate(request, reply);
         }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,13 +66,22 @@ exports.register = function (server, options, next) {
         // Validate incoming crumb
 
         if (typeof request.route.settings.plugins._crumb === 'undefined') {
-            request.route.settings.plugins._crumb = Hoek.applyToDefaults(routeDefaults, request.route.settings.plugins.crumb || {});
+            if (request.route.settings.plugins.crumb ||
+                !request.route.settings.plugins.hasOwnProperty('crumb')) {
+
+                request.route.settings.plugins._crumb = Hoek.applyToDefaults(routeDefaults, request.route.settings.plugins.crumb || {});
+            }
+            else {
+                request.route.settings.plugins._crumb = false;
+            }
         }
 
         // Set crumb cookie and calculate crumb
 
-        if (settings.autoGenerate &&
+        if ((settings.autoGenerate ||
+            request.route.settings.plugins._crumb) &&
             (request.route.settings.cors ? checkCORS(request) : true)) {
+
             generate(request, reply);
         }
 


### PR DESCRIPTION
Setting autoGenerate to false not only disabled automatically setting the cookie for every route, it also resulted in not READING the cookie for every route.

The problem is that the author combined READING the cookie with SETTING the cookie.

My solution, so far, is to ensure that we always try to READ the cookie, even if we aren't going to be SETTING (autoGenerating) the cookie.

I'm thinking that a better solution may be to separate the reading and setting so that they don't both reside in a function called generate, which seems weird to me.