### PR TITLE
adds logUnauthorized option - addresses #56

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ The following options are available when registering the plugin.
   * `cookieOptions` - storage options for the cookie containing the crumb, see the [server.state](http://hapijs.com/api#serverstatename-options) documentation of hapi for more information. Default to `cookieOptions.path=/`
   * `restful` - RESTful mode that validates crumb tokens from *"X-CSRF-Token"* request header for **POST**, **PUT**, **PATCH** and **DELETE** server routes. Disables payload/query crumb validation. Defaults to `false`.
   * `skip` - a function with the signature of `function (request, h) {}`, which when provided, is called for every request. If the provided function returns true, validation and generation of crumb is skipped. Defaults to `false`.
-
+  * 'logUnauthorized' - whether to add to the request log with tag 'crumb' and data 'validation failed' (defaults to false)
+  
 ### Routes configuration
 
 Additionally, some configuration can be passed on a per-route basis. Disable Crumb for a particular route by passing `false` instead of a configuration object.

--- a/lib/index.js
+++ b/lib/index.js
@@ -58,7 +58,7 @@ const register = (server, options) => {
         const unauthorizedLogger = () => {
 
             if (settings.logUnauthorized) {
-                request.log(['crumb'], 'validation failed');
+                request.log(['crumb', 'unauthorized'], 'validation failed');
             }
         };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,8 @@ internals.schema = Joi.object().keys({
     addToViewContext: Joi.boolean().optional(),
     cookieOptions: Joi.object().keys(null),
     restful: Joi.boolean().optional(),
-    skip: Joi.func().optional()
+    skip: Joi.func().optional(),
+    logUnauthorized: Joi.boolean().optional()
 });
 
 
@@ -34,7 +35,8 @@ internals.defaults = {
         path: '/'
     },
     restful: false,                 // Set to true for X-CSRF-Token header crumb validation. Disables payload/query validation
-    skip: false                    // Set to a function which returns true when to skip crumb generation and validation
+    skip: false,                    // Set to a function which returns true when to skip crumb generation and validation
+    logUnauthorized: false          // Set to true for crumb to write an event to the request log
 };
 
 const register = (server, options) => {
@@ -52,6 +54,13 @@ const register = (server, options) => {
     server.state(settings.key, settings.cookieOptions);
 
     server.ext('onPostAuth', (request, h) => {
+
+        const unauthorizedLogger = () => {
+
+            if (settings.logUnauthorized) {
+                request.log(['crumb'], 'validation failed');
+            }
+        };
 
         // If skip function enabled. Call it and if returns true, do not attempt to do anything with crumb.
 
@@ -97,11 +106,12 @@ const register = (server, options) => {
 
             const content = request[request.route.settings.plugins._crumb.source];
             if (!content || content instanceof Stream) {
-
+                unauthorizedLogger();
                 throw Boom.forbidden();
             }
 
             if (content[request.route.settings.plugins._crumb.key] !== request.plugins.crumb) {
+                unauthorizedLogger();
                 throw Boom.forbidden();
             }
 
@@ -119,10 +129,12 @@ const register = (server, options) => {
             const header = request.headers['x-csrf-token'];
 
             if (!header) {
+                unauthorizedLogger();
                 throw Boom.forbidden();
             }
 
             if (header !== request.plugins.crumb) {
+                unauthorizedLogger();
                 throw Boom.forbidden();
             }
 

--- a/test/index.js
+++ b/test/index.js
@@ -316,18 +316,15 @@ describe('Crumb', () => {
 
         const server = new Hapi.Server();
 
-        let logFound = false;
+        let logFound;
         const preResponse = function (request, h) {
 
             const logs = request.logs;
-            const found = logs.find((log) => {
+            logFound = logs.find((log) => {
 
                 return log.tags[0] === 'crumb' && log.data === 'validation failed';
             });
 
-            if (found) {
-                logFound = true;
-            }
             return h.continue;
         };
 
@@ -361,25 +358,22 @@ describe('Crumb', () => {
             url: '/1',
             headers
         });
-        expect(logFound).to.equal(true);
+        expect(logFound).to.exist();
     });
 
     it('Does not add to the request log if plugin option logUnauthorized is set to false', async () => {
 
         const server = new Hapi.Server();
 
-        let logFound = true;
+        let logFound;
         const preResponse = function (request, h) {
 
             const logs = request.logs;
-            const found = logs.find((log) => {
+            logFound = logs.find((log) => {
 
                 return log.tags[0] === 'crumb' && log.data === 'validation failed';
             });
 
-            if (!found) {
-                logFound = false;
-            }
             return h.continue;
         };
 
@@ -414,7 +408,7 @@ describe('Crumb', () => {
             headers
         });
 
-        expect(logFound).to.equal(false);
+        expect(logFound).to.not.exist();
     });
 
     it('should fail to register with bad options', async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -312,6 +312,111 @@ describe('Crumb', () => {
         expect(res.result).to.equal(Views.viewWithCrumb(cookie[1]));
     });
 
+    it('Adds to the request log if plugin option logUnauthorized is set to true', async () => {
+
+        const server = new Hapi.Server();
+
+        let logFound = false;
+        const preResponse = function (request, h) {
+
+            const logs = request.logs;
+            const found = logs.find((log) => {
+
+                return log.tags[0] === 'crumb' && log.data === 'validation failed';
+            });
+
+            if (found) {
+                logFound = true;
+            }
+            return h.continue;
+        };
+
+        server.ext('onPreResponse', preResponse);
+
+        server.route({
+            method: 'POST',
+            path: '/1',
+            config: {
+                log: {
+                    collect: true
+                }
+            },
+            handler: (request, h) => 'test'
+        });
+
+        await server.register([
+            {
+                plugin: Crumb,
+                options: {
+                    logUnauthorized: true
+                }
+            }
+        ]);
+
+        const headers = {};
+        headers['X-API-Token'] = 'test';
+
+        await server.inject({
+            method: 'POST',
+            url: '/1',
+            headers
+        });
+        expect(logFound).to.equal(true);
+    });
+
+    it('Does not add to the request log if plugin option logUnauthorized is set to false', async () => {
+
+        const server = new Hapi.Server();
+
+        let logFound = true;
+        const preResponse = function (request, h) {
+
+            const logs = request.logs;
+            const found = logs.find((log) => {
+
+                return log.tags[0] === 'crumb' && log.data === 'validation failed';
+            });
+
+            if (!found) {
+                logFound = false;
+            }
+            return h.continue;
+        };
+
+        server.ext('onPreResponse', preResponse);
+
+        server.route({
+            method: 'POST',
+            path: '/1',
+            config: {
+                log: {
+                    collect: true
+                }
+            },
+            handler: (request, h) => 'test'
+        });
+
+        await server.register([
+            {
+                plugin: Crumb,
+                options: {
+                    logUnauthorized: false
+                }
+            }
+        ]);
+
+        const headers = {};
+        headers['X-API-Token'] = 'test';
+
+        await server.inject({
+            method: 'POST',
+            url: '/1',
+            headers
+        });
+
+        expect(logFound).to.equal(false);
+    });
+
     it('should fail to register with bad options', async () => {
 
         const server = new Hapi.Server();


### PR DESCRIPTION
This adds a logUnauthorized option (default false) which calls request.log(['crumb'], 'validation failed') if enabled, when crumb denies a request.