### PR TITLE
Logunauthorized to 6.x.x - addresses #56

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The following options are available when registering the plugin
 * 'cookieOptions' - storage options for the cookie containing the crumb, see the [server.state](http://hapijs.com/api#serverstatename-options) documentation of hapi for more information
 * 'restful' - RESTful mode that validates crumb tokens from "X-CSRF-Token" request header for POST, PUT, PATCH and DELETE server routes. Disables payload/query crumb validation (defaults to false)
 * 'skip' - a function with the signature of `function (request, reply) {}`, which when provided, is called for every request. If the provided function returns true, validation and generation of crumb is skipped (defaults to false)
+* 'logUnauthorized' - whether to add to the request log with tag 'crumb' and data 'validation failed' (defaults to false)
 
 Additionally, some configuration can be passed on a per-route basis
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,7 @@ exports.register = function (server, options, next) {
         const unauthorizedLogger = () => {
 
             if (settings.logUnauthorized) {
-                request.log(['crumb'], 'validation failed');
+                request.log(['crumb', 'unauthorized'], 'validation failed');
             }
         };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,7 +21,8 @@ internals.schema = Joi.object().keys({
     addToViewContext: Joi.boolean().optional(),
     cookieOptions: Joi.object().keys(null),
     restful: Joi.boolean().optional(),
-    skip: Joi.func().optional()
+    skip: Joi.func().optional(),
+    logUnauthorized: Joi.boolean().optional()
 });
 
 
@@ -34,7 +35,8 @@ internals.defaults = {
         path: '/'
     },
     restful: false,                 // Set to true for X-CSRF-Token header crumb validation. Disables payload/query validation
-    skip: false                    // Set to a function which returns true when to skip crumb generation and validation
+    skip: false,                    // Set to a function which returns true when to skip crumb generation and validation
+    logUnauthorized: false          // Set to true for crumb to write an event to the request log
 };
 
 
@@ -56,6 +58,12 @@ exports.register = function (server, options, next) {
     server.state(settings.key, settings.cookieOptions);
 
     server.ext('onPostAuth', (request, reply) => {
+
+        const unauthorizedLogger = () => {
+            if (settings.logUnauthorized) {
+                request.log(['crumb'], 'validation failed')
+            }
+        }
 
         // If skip function enabled. Call it and if returns true, do not attempt to do anything with crumb.
 
@@ -101,11 +109,12 @@ exports.register = function (server, options, next) {
 
             const content = request[request.route.settings.plugins._crumb.source];
             if (!content || content instanceof Stream) {
-
+                unauthorizedLogger()
                 return reply(Boom.forbidden());
             }
 
             if (content[request.route.settings.plugins._crumb.key] !== request.plugins.crumb) {
+                unauthorizedLogger()
                 return reply(Boom.forbidden());
             }
 
@@ -123,10 +132,12 @@ exports.register = function (server, options, next) {
             const header = request.headers['x-csrf-token'];
 
             if (!header) {
+                unauthorizedLogger()
                 return reply(Boom.forbidden());
             }
 
             if (header !== request.plugins.crumb) {
+                unauthorizedLogger()
                 return reply(Boom.forbidden());
             }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,10 +60,11 @@ exports.register = function (server, options, next) {
     server.ext('onPostAuth', (request, reply) => {
 
         const unauthorizedLogger = () => {
+
             if (settings.logUnauthorized) {
-                request.log(['crumb'], 'validation failed')
+                request.log(['crumb'], 'validation failed');
             }
-        }
+        };
 
         // If skip function enabled. Call it and if returns true, do not attempt to do anything with crumb.
 
@@ -109,12 +110,12 @@ exports.register = function (server, options, next) {
 
             const content = request[request.route.settings.plugins._crumb.source];
             if (!content || content instanceof Stream) {
-                unauthorizedLogger()
+                unauthorizedLogger();
                 return reply(Boom.forbidden());
             }
 
             if (content[request.route.settings.plugins._crumb.key] !== request.plugins.crumb) {
-                unauthorizedLogger()
+                unauthorizedLogger();
                 return reply(Boom.forbidden());
             }
 
@@ -132,12 +133,12 @@ exports.register = function (server, options, next) {
             const header = request.headers['x-csrf-token'];
 
             if (!header) {
-                unauthorizedLogger()
+                unauthorizedLogger();
                 return reply(Boom.forbidden());
             }
 
             if (header !== request.plugins.crumb) {
-                unauthorizedLogger()
+                unauthorizedLogger();
                 return reply(Boom.forbidden());
             }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "code": "2.x.x",
     "handlebars": "^4.0.5",
-    "hapi": "13.x.x",
+    "hapi": "16.x.x",
     "lab": "10.x.x",
     "vision": "^4.0.0"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -275,18 +275,15 @@ describe('Crumb', () => {
         const server = new Hapi.Server();
         server.connection();
 
-        let logFound = false;
+        let logFound;
         const preResponse = function (request, reply) {
 
             const logs = request.getLog();
-            const found = logs.find((log) => {
+            logFound = logs.find((log) => {
 
                 return log.tags[0] === 'crumb' && log.data === 'validation failed';
             });
 
-            if (found) {
-                logFound = true;
-            }
             return reply.continue();
         };
 
@@ -322,7 +319,7 @@ describe('Crumb', () => {
                 headers
             }, () => {
 
-                expect(logFound).to.equal(true);
+                expect(logFound).to.exist();
                 done();
             });
         });
@@ -333,18 +330,15 @@ describe('Crumb', () => {
         const server = new Hapi.Server();
         server.connection();
 
-        let logFound = true;
+        let logFound;
         const preResponse = function (request, reply) {
 
             const logs = request.getLog();
-            const found = logs.find((log) => {
+            logFound = logs.find((log) => {
 
                 return log.tags[0] === 'crumb' && log.data === 'validation failed';
             });
 
-            if (!found) {
-                logFound = false;
-            }
             return reply.continue();
         };
 
@@ -379,7 +373,7 @@ describe('Crumb', () => {
                 url: '/1'
             }, () => {
 
-                expect(logFound).to.equal(false);
+                expect(logFound).to.not.exist();
                 done();
             });
         });


### PR DESCRIPTION
This establishes a pre-hapi 17 6.x.x branch of crumb, and then adds a logUnauthorized option (default false) which calls request.log(['crumb'], 'validation failed') if enabled, when crumb denies a request.