### PR TITLE
Issue 118: crumb fails when there are multiple cookies with the same name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,6 +64,23 @@ const register = (server, options) => {
             }
         };
 
+        const multipleCookieLogger = () => {
+
+            request.log(['crumb'], 'multiple cookies found');
+        };
+
+        const getCrumbValue = () => {
+
+            let crumbValue = request.plugins.crumb;
+
+            if (Array.isArray(crumbValue)) {
+                multipleCookieLogger();
+                crumbValue = request.plugins.crumb[0];
+            }
+
+            return crumbValue;
+        };
+
         // If skip function enabled. Call it and if returns true, do not attempt to do anything with crumb.
 
         if (settings.skip && settings.skip(request, h)) {
@@ -112,7 +129,8 @@ const register = (server, options) => {
                 throw Boom.forbidden();
             }
 
-            if (content[request.route.settings.plugins._crumb.key] !== request.plugins.crumb) {
+
+            if (content[request.route.settings.plugins._crumb.key] !== getCrumbValue()) {
                 unauthorizedLogger();
                 throw Boom.forbidden();
             }
@@ -135,7 +153,7 @@ const register = (server, options) => {
                 throw Boom.forbidden();
             }
 
-            if (header !== request.plugins.crumb) {
+            if (header !== getCrumbValue()) {
                 unauthorizedLogger();
                 throw Boom.forbidden();
             }


### PR DESCRIPTION
This is my contribution of a fix for issue #118.

In short:
* If an array value is found for the relevant cookie
    * this logs a request message indicating that there are too many cookies found
    * plucks out the first cookie value and uses that for the comparison.

Feedback welcomed.

p.s. GitHub reminded me to look at your contribution guidelines (CONTRIBUTING.md in this repo) but it points to a non-existent contributing guide in hapijs/hapi.  