### PR TITLE
validate crumb when autoGenerate is false and crumb not defined on route

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -96,8 +96,7 @@ exports.plugin = {
             // Validate incoming crumb
 
             if (request.route.settings.plugins._crumb === undefined) {
-                if (request.route.settings.plugins.crumb ||
-                    !request.route.settings.plugins.hasOwnProperty('crumb') && settings.autoGenerate) {
+                if (request.route.settings.plugins.crumb || !request.route.settings.plugins.hasOwnProperty('crumb')) {
 
                     request.route.settings.plugins._crumb = Hoek.applyToDefaults(routeDefaults, request.route.settings.plugins.crumb || {});
                 }
@@ -108,7 +107,7 @@ exports.plugin = {
 
             // Set crumb cookie and calculate crumb
 
-            if ((settings.autoGenerate || request.route.settings.plugins._crumb) &&
+            if ((settings.autoGenerate || request.route.settings.plugins.crumb) &&
                 (!request.route.settings.cors || checkCORS(request))) {
 
                 generate(request, h);

--- a/test/index.js
+++ b/test/index.js
@@ -506,6 +506,38 @@ describe('Crumb', () => {
         expect(header.length).to.equal(1);
     });
 
+    it('route should still validate crumb when autoGenerate is false and route.options.plugins.crumb is not defined', async () => {
+
+        const server = new Hapi.Server();
+
+        server.route([
+            {
+                method: 'POST',
+                path: '/1',
+                handler: (request, h) => {
+
+                    return 'bonjour';
+                }
+            }
+        ]);
+
+        await server.register([
+            Vision,
+            {
+                plugin: Crumb,
+                options: {
+                    autoGenerate: false
+                }
+            }
+        ]);
+
+        server.views(internals.viewOptions);
+
+        const res = await server.inject({ method: 'POST', url: '/1' });
+
+        expect(res.statusCode).to.equal(403);
+    });
+
     it('fails validation when no payload provided and not using restful mode', async () => {
 
         const server = new Hapi.Server();


### PR DESCRIPTION
If you set autoGenerate to false, it disables crumb validation on routes which do not defined crumb options.

This fix ensures that autoGenerate does not affect crumb validation, while still being used properly to affect crumb generation.

Related issues: #108 and #94