### PR TITLE
validate crumb when autoGenerate is false and crumb not defined on route

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -96,8 +96,7 @@ exports.plugin = {
             // Validate incoming crumb
 
             if (request.route.settings.plugins._crumb === undefined) {
-                if (request.route.settings.plugins.crumb ||
-                    !request.route.settings.plugins.hasOwnProperty('crumb') && settings.autoGenerate) {
+                if (request.route.settings.plugins.crumb || !request.route.settings.plugins.hasOwnProperty('crumb')) {
 
                     request.route.settings.plugins._crumb = Hoek.applyToDefaults(routeDefaults, request.route.settings.plugins.crumb || {});
                 }
@@ -108,7 +107,7 @@ exports.plugin = {
 
             // Set crumb cookie and calculate crumb
 
-            if ((settings.autoGenerate || request.route.settings.plugins._crumb) &&
+            if ((settings.autoGenerate || request.route.settings.plugins.crumb) &&
                 (!request.route.settings.cors || checkCORS(request))) {
 
                 generate(request, h);

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,7 +93,7 @@ exports.plugin = {
                 return h.continue;
             }
 
-            // Validate incoming crumb
+            // Get crumb settings for this route if crumb is enabled on route
 
             if (request.route.settings.plugins._crumb === undefined) {
                 if (request.route.settings.plugins.crumb || !request.route.settings.plugins.hasOwnProperty('crumb')) {
@@ -105,12 +105,16 @@ exports.plugin = {
                 }
             }
 
-            // Set crumb cookie and calculate crumb
+            if (!request.route.settings.cors || checkCORS(request)) {
+                // Read crumb value from cookie if crumb enabled for this route
+                if (request.route.settings.plugins._crumb) {
+                    readCrumb(request);
+                }
 
-            if ((settings.autoGenerate || request.route.settings.plugins.crumb) &&
-                (!request.route.settings.cors || checkCORS(request))) {
-
-                generate(request, h);
+                // Generate crumb value if autoGenerate enabled or crumb specifically enabled on route
+                if (settings.autoGenerate || request.route.settings.plugins.crumb) {
+                    generate(request, h);
+                }
             }
 
             // Skip validation on dry run
@@ -199,13 +203,18 @@ exports.plugin = {
 
         const generate = function (request, h) {
 
-            let crumb = request.state[settings.key];
-            if (!crumb) {
-                crumb = Cryptiles.randomString(settings.size);
+            if (!request.plugins.crumb) {
+                const crumb = Cryptiles.randomString(settings.size);
                 h.state(settings.key, crumb, settings.cookieOptions);
+                request.plugins.crumb = crumb;
             }
 
-            request.plugins.crumb = crumb;
+            return request.plugins.crumb;
+        };
+
+        const readCrumb = function (request) {
+
+            request.plugins.crumb = request.state[settings.key];
             return request.plugins.crumb;
         };
 

--- a/test/index.js
+++ b/test/index.js
@@ -506,6 +506,38 @@ describe('Crumb', () => {
         expect(header.length).to.equal(1);
     });
 
+    it('route should still validate crumb when autoGenerate is false and route.options.plugins.crumb is not defined', async () => {
+
+        const server = new Hapi.Server();
+
+        server.route([
+            {
+                method: 'POST',
+                path: '/1',
+                handler: (request, h) => {
+
+                    return 'bonjour';
+                }
+            }
+        ]);
+
+        await server.register([
+            Vision,
+            {
+                plugin: Crumb,
+                options: {
+                    autoGenerate: false
+                }
+            }
+        ]);
+
+        server.views(internals.viewOptions);
+
+        const res = await server.inject({ method: 'POST', url: '/1' });
+
+        expect(res.statusCode).to.equal(403);
+    });
+
     it('fails validation when no payload provided and not using restful mode', async () => {
 
         const server = new Hapi.Server();

--- a/test/index.js
+++ b/test/index.js
@@ -526,16 +526,27 @@ describe('Crumb', () => {
             {
                 plugin: Crumb,
                 options: {
-                    autoGenerate: false
+                    autoGenerate: false,
+                    restful: true
                 }
             }
         ]);
 
         server.views(internals.viewOptions);
 
-        const res = await server.inject({ method: 'POST', url: '/1' });
-
+        let res = await server.inject({ method: 'POST', url: '/1' });
         expect(res.statusCode).to.equal(403);
+
+        const crumbValue = 'someCrumbValue';
+        res = await server.inject({
+            method: 'POST',
+            url: '/1',
+            headers: {
+                cookie: `crumb=${crumbValue}`,
+                'X-CSRF-token': crumbValue
+            }
+        });
+        expect(res.statusCode).to.equal(200);
     });
 
     it('fails validation when no payload provided and not using restful mode', async () => {


### PR DESCRIPTION
When autoGenerate is false, and the crumb is undefined on the route, the route never validates incoming crumb values.

Fixing this required:
  * gathering crumb settings for route even if autoGenerate is false and crumb is undefined for route
  * separating the reading of the crumb cookie from the generation of a new crumb value
  * read crumb cookie if crumb is enabled on route
  * generate crumb cookie if autoGenerate is true or crumb defined for route