### PR TITLE
Node 14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,6 @@
-language: node_js
+version: ~> 1.0
 
-node_js:
-  - "12"
-  - "node"
-
-sudo: false
-
-install:
-  - "npm install"
-  - "npm install @hapi/hapi@$HAPI_VERSION"
-
-env:
-  - HAPI_VERSION="19"
-
-os:
-  - "linux"
-  - "osx"
-  - "windows"
+import:
+  - hapijs/ci-config-travis:node_js.yml@main
+  - hapijs/ci-config-travis:install.yml@main
+  - hapijs/ci-config-travis:os.yml@main

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",
-    "@hapi/hapi": "19.x.x",
+    "@hapi/hapi": "20.x.x",
     "@hapi/lab": "23.x.x",
     "@hapi/vision": "6.x.x",
     "handlebars": "4.x.x"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@hapi/hapi": "20.x.x",
     "@hapi/lab": "23.x.x",
     "@hapi/vision": "6.x.x",
-    "handlebars": "4.x.x"
+    "handlebars": "^4.6.0"
   },
   "scripts": {
     "test": "lab -t 100 -a @hapi/code -L",


### PR DESCRIPTION
- Use Travis templates.
- Tests pass on Node 14.
- Update @hapi/hapi to v20.
- Specify a minimum version for handlebars: 4.x.x was doing the trick to get the security patched version but I specified that version as a minimum in the major range. Is that how you wanted to tackle it @cjihrig?