### PR TITLE
update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
   },
   "devDependencies": {
     "@hapi/code": "8.x.x",
-    "@hapi/hapi": "19.x.x",
+    "@hapi/hapi": "20.x.x",
     "@hapi/lab": "23.x.x",
     "@hapi/vision": "6.x.x",
-    "handlebars": "4.x.x"
+    "handlebars": "^4.7.0"
   },
   "scripts": {
     "test": "lab -t 100 -a @hapi/code -L",


### PR DESCRIPTION
This commit updates hapi to v20 and also enforces a stricter
minimum version of handlebars to avoid a security vulnerability.

Refs: https://github.com/hapijs/crumb/pull/148