### PR TITLE
Support for hapi v21, node v18, ESM tests

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -10,3 +10,6 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-plugin.yml@master
+    with:
+      min-node-version: 14
+      min-hapi-version: 20

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,5 @@
-Copyright (c) 2013-2020, Sideway Inc, and project contributors  
+Copyright (c) 2013-2022, Project contributors
+Copyright (c) 2013-2020, Sideway Inc
 Copyright (c) 2013-2014, Walmart.  
 All rights reserved.
 

--- a/example/restful.js
+++ b/example/restful.js
@@ -5,7 +5,7 @@ const Hapi = require('@hapi/hapi');
 const Vision = require('@hapi/vision');
 
 
-const server = new Hapi.Server({
+const server = Hapi.server({
     host: '127.0.0.1',
     port: 8000
 });

--- a/example/server.js
+++ b/example/server.js
@@ -5,7 +5,7 @@ const Hapi = require('@hapi/hapi');
 const Vision = require('@hapi/vision');
 
 
-const server = new Hapi.Server({
+const server = Hapi.server({
     host: '127.0.0.1',
     port: 8000
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,9 +46,8 @@ internals.defaults = {
 exports.plugin = {
     pkg: require('../package.json'),
     requirements: {
-        hapi: '>=19.0.0'
+        hapi: '>=20.0.0'
     },
-
     register: function (server, options) {
 
         Validate.assert(options, internals.schema);
@@ -98,7 +97,7 @@ exports.plugin = {
                 if (request.route.settings.plugins.crumb ||
                     !request.route.settings.plugins.hasOwnProperty('crumb')) {
 
-                    request.route.settings.plugins._crumb = Hoek.applyToDefaults(routeDefaults, request.route.settings.plugins.crumb || {});
+                    request.route.settings.plugins._crumb = Hoek.applyToDefaults(routeDefaults, request.route.settings.plugins.crumb ?? {});
                 }
                 else {
                     request.route.settings.plugins._crumb = false;
@@ -191,7 +190,7 @@ exports.plugin = {
                 !response.isBoom &&
                 response.variety === 'view') {
 
-                response.source.context = response.source.context || {};
+                response.source.context = response.source.context ?? {};
                 response.source.context[request.route.settings.plugins._crumb.key] = request.plugins.crumb;
             }
 

--- a/package.json
+++ b/package.json
@@ -20,17 +20,17 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x",
-    "@hapi/cryptiles": "5.x.x",
-    "@hapi/hoek": "9.x.x",
-    "@hapi/validate": "1.x.x"
+    "@hapi/boom": "^10.0.0",
+    "@hapi/cryptiles": "^6.0.0",
+    "@hapi/hoek": "^10.0.0",
+    "@hapi/validate": "^2.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
-    "@hapi/eslint-plugin": "*",
-    "@hapi/hapi": "20.x.x",
-    "@hapi/lab": "24.x.x",
-    "@hapi/vision": "6.x.x",
+    "@hapi/code": "^9.0.0",
+    "@hapi/eslint-plugin": "^6.0.0",
+    "@hapi/hapi": "^21.0.0-beta.1",
+    "@hapi/lab": "^25.0.1",
+    "@hapi/vision": "^7.0.0",
     "handlebars": "^4.7.7"
   },
   "scripts": {

--- a/test/esm.js
+++ b/test/esm.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const Code = require('@hapi/code');
+const Lab = require('@hapi/lab');
+
+
+const { before, describe, it } = exports.lab = Lab.script();
+const expect = Code.expect;
+
+
+describe('import()', () => {
+
+    let Crumb;
+
+    before(async () => {
+
+        Crumb = await import('../lib/index.js');
+    });
+
+    it('exposes all methods and classes as named imports', () => {
+
+        expect(Object.keys(Crumb)).to.equal([
+            'default',
+            'plugin'
+        ]);
+    });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -30,7 +30,7 @@ describe('Crumb', () => {
 
     it('returns view with crumb', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
 
         server.route([
             {
@@ -258,7 +258,7 @@ describe('Crumb', () => {
 
     it('Does not add crumb to view context when "addToViewContext" option set to false', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
 
         server.route({
             method: 'GET',
@@ -301,7 +301,7 @@ describe('Crumb', () => {
 
     it('Works without specifying plugin options', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
 
         server.route({
             method: 'GET',
@@ -336,7 +336,7 @@ describe('Crumb', () => {
 
     it('Adds to the request log if plugin option logUnauthorized is set to true', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
 
         let logFound;
         const preResponse = function (request, h) {
@@ -386,7 +386,7 @@ describe('Crumb', () => {
 
     it('Does not add to the request log if plugin option logUnauthorized is set to false', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
 
         let logFound;
         const preResponse = function (request, h) {
@@ -436,7 +436,7 @@ describe('Crumb', () => {
 
     it('should fail to register with bad options', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
 
         try {
             await server.register({
@@ -456,7 +456,7 @@ describe('Crumb', () => {
 
     it('route uses crumb when route.options.plugins.crumb set to true and autoGenerate set to false', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
 
         server.route([
             {
@@ -508,7 +508,7 @@ describe('Crumb', () => {
 
     it('route should still validate crumb when autoGenerate is false and route.options.plugins.crumb is not defined', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
 
         server.route([
             {
@@ -551,7 +551,7 @@ describe('Crumb', () => {
 
     it('fails validation when no payload provided and not using restful mode', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
 
         server.route({
             method: 'POST',
@@ -575,7 +575,7 @@ describe('Crumb', () => {
 
     it('does not validate crumb when "skip" option returns true', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
 
         server.route({
             method: 'POST',
@@ -614,7 +614,7 @@ describe('Crumb', () => {
 
     it('validates crumb when "skip" option returns false', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
 
         server.route({
             method: 'POST',
@@ -650,7 +650,7 @@ describe('Crumb', () => {
 
     it('ensures crumb "skip" option is a function', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
 
         server.route({
             method: 'POST',
@@ -676,7 +676,7 @@ describe('Crumb', () => {
 
     it('does not set crumb cookie insecurely', async () => {
 
-        const server = new Hapi.Server({
+        const server = Hapi.server({
             host: 'localhost',
             port: 80,
             routes: {
@@ -775,7 +775,7 @@ describe('Crumb', () => {
             tls: TLSCert
         };
 
-        const server = new Hapi.Server(options);
+        const server = Hapi.server(options);
 
         server.route([
             {
@@ -801,7 +801,7 @@ describe('Crumb', () => {
 
     it('validates crumb with X-CSRF-Token header', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
 
         server.route([
             {
@@ -1032,7 +1032,7 @@ describe('Crumb', () => {
 
     it('validates crumb with a custom header name', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
 
         server.route([
             {
@@ -1264,7 +1264,7 @@ describe('Crumb', () => {
 
     it('Adds to the request log if there are multiple cookie values', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
         let logFound;
 
         const preResponse = function (request, h) {
@@ -1338,7 +1338,7 @@ describe('Crumb', () => {
 
     it('Adds to the request log if there are multiple cookie values in restful mode', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
         let logFound;
 
         const preResponse = function (request, h) {
@@ -1416,7 +1416,7 @@ describe('Crumb', () => {
 
     it('should set cookie but ignore check with enforce flag turned off', async () => {
 
-        const server = new Hapi.Server();
+        const server = Hapi.server();
 
         server.route({
             method: 'POST',


### PR DESCRIPTION
 - Support and test on hapi v21, drop support for hapi v19.
 - Support and test on node v18, utilize some newer JS syntax.
 - Update all deps for node v18 and hapi v21.
 - Test ESM support.

If this looks good, this will go out as crumb v9.