### PR TITLE
Fix disabling of `crumb` plugin via `route.options.plugins.crumb: false`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -101,6 +101,7 @@ exports.plugin = {
                 }
                 else {
                     request.route.settings.plugins._crumb = false;
+                    return h.continue;
                 }
             }
 
@@ -109,9 +110,7 @@ exports.plugin = {
 
                 // Read crumb value from cookie if crumb enabled for this route
 
-                if (request.route.settings.plugins._crumb) {
-                    request.plugins.crumb = request.state[settings.key];
-                }
+                request.plugins.crumb = request.state[settings.key];
 
                 // Generate crumb value if autoGenerate enabled or crumb specifically enabled on route
 
@@ -130,9 +129,9 @@ exports.plugin = {
 
             // Validate crumb
 
-            const restful = request.route.settings.plugins._crumb ? request.route.settings.plugins._crumb.restful : settings.restful;
+            const restful = request.route.settings.plugins._crumb.restful;
             if (restful) {
-                if (!internals.restfulValidatedMethods.includes(request.method) || !request.route.settings.plugins._crumb) {
+                if (!internals.restfulValidatedMethods.includes(request.method)) {
                     return h.continue;
                 }
 
@@ -153,8 +152,7 @@ exports.plugin = {
 
             // Not restful
 
-            if (!request.route.settings.plugins._crumb ||
-                request.method !== 'post') {
+            if (request.method !== 'post') {
 
                 return h.continue;
             }
@@ -186,7 +184,6 @@ exports.plugin = {
 
             if (settings.addToViewContext &&
                 request.plugins.crumb &&
-                request.route.settings.plugins._crumb &&
                 !response.isBoom &&
                 response.variety === 'view') {
 

--- a/test/index.js
+++ b/test/index.js
@@ -573,6 +573,45 @@ describe('Crumb', () => {
         expect(res.statusCode).to.equal(403);
     });
 
+    it('does not validate crumb when route.options.plugins.crumb is false', async () => {
+
+        const server = Hapi.server();
+
+        server.route({
+            method: 'POST',
+            path: '/1',
+            options: {
+                plugins: {
+                    crumb: false
+                }
+            },
+            handler: (request, h) => 'test'
+        });
+
+        const plugins = [
+            {
+                plugin: Crumb
+            }
+        ];
+
+        await server.register(plugins);
+
+        const headers = {
+            'X-API-Token': 'test'
+        };
+
+        const res = await server.inject({
+            method: 'POST',
+            url: '/1',
+            headers
+        });
+
+        const header = res.headers['set-cookie'];
+
+        expect(res.statusCode).to.equal(200);
+        expect(header).to.not.exist();
+    });
+
     it('does not validate crumb when "skip" option returns true', async () => {
 
         const server = Hapi.server();


### PR DESCRIPTION
Return early if `request.route.settings.plugins.crumb` is falsy.

Fixes #165